### PR TITLE
Add CLI with load-sheet and demo commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Create a `.env` file:
 
 ```
 GOOGLE_SHEET_ID=your_google_sheet_id
+SERVICE_ACCOUNT=service_account.json
 ```
 
 ### 4. Add Google Service Account
@@ -71,6 +72,24 @@ streamlit run app/streamlit_app.py
 ```
 
 The app will launch at `http://localhost:8501`
+
+### Demo page
+
+If you just want to see a simple list of members, run:
+
+```bash
+streamlit run app/demo.py
+```
+
+### CLI usage
+
+Install the package in editable mode and use the built-in CLI:
+
+```bash
+pip install -e .
+member-dir load-sheet  # print member data as CSV
+member-dir demo        # open the demo in Streamlit
+```
 
 ---
 
@@ -108,4 +127,3 @@ For easy hosting, use:
 ## 📄 License
 
 MIT License. Built by [Tiana Smith](https://github.com/YOUR_USERNAME).
-$$

--- a/app/demo.py
+++ b/app/demo.py
@@ -1,0 +1,13 @@
+import streamlit as st
+from member_directory_app import load_members
+
+st.set_page_config(page_title="Members Demo")
+
+st.title("Member List Demo")
+
+members = load_members()
+
+if members.empty:
+    st.write("No member data available.")
+else:
+    st.dataframe(members)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,8 @@ dependencies = [
     "google-auth",
 ]
 
+[project.scripts]
+member-dir = "member_directory_app.cli:main"
+
 [tool.uv]
 # Optional: future settings go here

--- a/src/member_directory_app/__init__.py
+++ b/src/member_directory_app/__init__.py
@@ -1,21 +1,54 @@
 """Utilities for the member directory app."""
 
 from pathlib import Path
+import os
 import pandas as pd
+import gspread
+from google.oauth2 import service_account
 
 DATA_PATH = Path(__file__).resolve().parent.parent / "data" / "members.csv"
 
 
-def load_members() -> pd.DataFrame:
-    """Load member data from the local CSV file.
+def _load_from_google_sheet(sheet_id: str, credentials_path: str) -> pd.DataFrame:
+    """Fetch member records from a Google Sheet.
+
+    Parameters
+    ----------
+    sheet_id:
+        The ID of the Google Sheet.
+    credentials_path:
+        Path to a service account JSON credentials file.
 
     Returns
     -------
     pandas.DataFrame
-        Table of members.
+        Data from the first worksheet of the sheet.
     """
+    creds = service_account.Credentials.from_service_account_file(
+        credentials_path,
+        scopes=["https://www.googleapis.com/auth/spreadsheets.readonly"],
+    )
+    client = gspread.authorize(creds)
+    sheet = client.open_by_key(sheet_id)
+    worksheet = sheet.sheet1
+    records = worksheet.get_all_records()
+    return pd.DataFrame(records)
+
+
+def load_members() -> pd.DataFrame:
+    """Load member data from Google Sheets if configured, otherwise from CSV."""
+    sheet_id = os.getenv("GOOGLE_SHEET_ID")
+    service_account_path = os.getenv("SERVICE_ACCOUNT", "service_account.json")
+
+    if sheet_id and Path(service_account_path).exists():
+        try:
+            return _load_from_google_sheet(sheet_id, service_account_path)
+        except Exception as exc:  # pragma: no cover - network dependency
+            print(f"Failed to load Google Sheet: {exc}")
+
     if DATA_PATH.exists():
         return pd.read_csv(DATA_PATH)
+
     return pd.DataFrame(columns=["Name", "Department", "Email"])
 
 

--- a/src/member_directory_app/__main__.py
+++ b/src/member_directory_app/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/src/member_directory_app/cli.py
+++ b/src/member_directory_app/cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from . import load_members
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the member directory CLI."""
+    parser = argparse.ArgumentParser(description="Member Directory CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser(
+        "load-sheet", help="Load member data from Google Sheets and print as CSV"
+    )
+    subparsers.add_parser(
+        "demo", help="Launch the Streamlit demo page listing members"
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "load-sheet":
+        df = load_members()
+        if df.empty:
+            print("No member data found.")
+        else:
+            print(df.to_csv(index=False))
+    elif args.command == "demo":
+        demo_path = Path(__file__).resolve().parents[1] / "app" / "demo.py"
+        subprocess.run(["streamlit", "run", str(demo_path)], check=False)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION
## Summary
- implement a small CLI with `load-sheet` and `demo` commands
- expose CLI via `member-dir` console script
- document CLI usage in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bc16d84188328b69e04510e23914c